### PR TITLE
Pallet XCM - transfer_assets pre-ahm patch 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11206,6 +11206,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex-literal",
  "log",
  "pallet-assets",
  "pallet-balances",
@@ -11221,6 +11222,7 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
+ "tracing",
 ]
 
 [[package]]

--- a/polkadot/xcm/pallet-xcm/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm/Cargo.toml
@@ -15,6 +15,8 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.195", optional = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
+tracing = { version = "0.1.29", default-features = false }
+hex-literal = { version = "0.4.1", default-features = true }
 
 frame-support = { path = "../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../substrate/frame/system", default-features = false }

--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -1556,6 +1556,16 @@ impl<T: Config> Pallet<T> {
 		// Ensure all assets (including fees) have same reserve location.
 		ensure!(assets_transfer_type == fees_transfer_type, Error::<T>::TooManyReserves);
 
+		// We check for network native asset reserve transfers in preparation for the Asset Hub
+		// Migration. This check will be removed after the migration and the determined
+		// reserve location adjusted accordingly. For more information, see https://github.com/paritytech/polkadot-sdk/issues/9054.
+		Self::ensure_network_asset_reserve_transfer_allowed(
+			&assets,
+			fee_asset_item,
+			&assets_transfer_type,
+			&fees_transfer_type,
+		)?;
+
 		Self::build_and_execute_xcm_transfer_type(
 			origin,
 			dest,

--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -24,6 +24,7 @@ pub mod benchmarking;
 mod mock;
 #[cfg(test)]
 mod tests;
+mod transfer_assets_validation;
 
 pub mod migration;
 
@@ -1333,6 +1334,16 @@ pub mod pallet {
 			// Find transfer types for fee and non-fee assets.
 			let (fees_transfer_type, assets_transfer_type) =
 				Self::find_fee_and_assets_transfer_types(&assets, fee_asset_item, &dest)?;
+
+			// We check for network native asset reserve transfers in preparation for the Asset Hub
+			// Migration. This check will be removed after the migration and the determined
+			// reserve location adjusted accordingly. For more information, see https://github.com/paritytech/polkadot-sdk/issues/9054.
+			Self::ensure_network_asset_reserve_transfer_allowed(
+				&assets,
+				fee_asset_item,
+				&assets_transfer_type,
+				&fees_transfer_type,
+			)?;
 
 			// local and remote XCM programs to potentially handle fees separately
 			let fees = if fees_transfer_type == assets_transfer_type {

--- a/polkadot/xcm/pallet-xcm/src/transfer_assets_validation.rs
+++ b/polkadot/xcm/pallet-xcm/src/transfer_assets_validation.rs
@@ -22,9 +22,9 @@
 use crate::{Config, Error, Pallet};
 use hex_literal::hex;
 use sp_core::Get;
+use sp_std::vec::Vec;
 use xcm::prelude::*;
 use xcm_executor::traits::TransferType;
-use sp_std::vec::Vec;
 
 /// The genesis hash of the Paseo Relay Chain. Used to identify it.
 const PASEO_GENESIS_HASH: [u8; 32] =
@@ -117,9 +117,9 @@ impl<T: Config> Pallet<T> {
 	fn is_network_native_asset(asset_id: &AssetId) -> bool {
 		let universal_location = T::UniversalLocation::get();
 		let asset_location = match asset_id {
-            AssetId::Concrete(location) => location,
-            AssetId::Abstract(_) => return false, // What case will this be?
-        };
+			AssetId::Concrete(location) => location,
+			AssetId::Abstract(_) => return false, // Do not allow abstract assets for this check.
+		};
 
 		match universal_location.len() {
 			// Case 1: We are on the Relay Chain itself.

--- a/polkadot/xcm/pallet-xcm/src/transfer_assets_validation.rs
+++ b/polkadot/xcm/pallet-xcm/src/transfer_assets_validation.rs
@@ -1,0 +1,170 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Validation of the `transfer_assets` call.
+//! This validation is a temporary patch in preparation for the Asset Hub Migration (AHM).
+//! This module will be removed after the migration and the determined
+//! reserve location will be adjusted accordingly to be Asset Hub.
+//! For more information, see <https://github.com/paritytech/polkadot-sdk/issues/9054>.
+use crate::{Config, Error, Pallet};
+use hex_literal::hex;
+use sp_core::Get;
+use xcm::prelude::*;
+use xcm_executor::traits::TransferType;
+
+/// The genesis hash of the Paseo Relay Chain. Used to identify it.
+const PASEO_GENESIS_HASH: [u8; 32] =
+	hex!["77afd6190f1554ad45fd0d31aee62aacc33c6db0ea801129acb813f913e0764f"];
+
+pub const WESTEND_GENESIS_HASH: [u8; 32] =
+	hex!["e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"];
+
+pub const ROCOCO_GENESIS_HASH: [u8; 32] =
+	hex!["6408de7737c59c238890533af25896a2c20608d8b380bb01029acb392781063e"];
+
+impl<T: Config> Pallet<T> {
+	/// Check if network native asset reserve transfers should be blocked during Asset Hub
+	/// Migration.
+	///
+	/// During the Asset Hub Migration (AHM), the native network asset's reserve will move
+	/// from the Relay Chain to Asset Hub. The `transfer_assets` function automatically determines
+	/// reserves based on asset ID location, which would incorrectly assume Relay Chain as the
+	/// reserve.
+	///
+	/// This function blocks native network asset reserve transfers to prevent issues during
+	/// the migration.
+	/// Users should use `limited_reserve_transfer_assets`, `transfer_assets_using_type_and_then` or
+	/// `execute` instead, which allows explicit reserve specification.
+	pub(crate) fn ensure_network_asset_reserve_transfer_allowed(
+		assets: &Vec<MultiAsset>,
+		fee_asset_index: usize,
+		assets_transfer_type: &TransferType,
+		fees_transfer_type: &TransferType,
+	) -> Result<(), Error<T>> {
+		// Extract fee asset and check both assets and fees separately.
+		let mut remaining_assets = assets.clone();
+		if fee_asset_index >= remaining_assets.len() {
+			return Err(Error::<T>::Empty);
+		}
+		let fee_asset = remaining_assets.remove(fee_asset_index);
+
+		// Check remaining assets with their transfer type.
+		Self::ensure_one_transfer_type_allowed(&remaining_assets, &assets_transfer_type)?;
+
+		// Check fee asset with its transfer type.
+		Self::ensure_one_transfer_type_allowed(&[fee_asset], &fees_transfer_type)?;
+
+		Ok(())
+	}
+
+	/// Checks that the transfer of `assets` is allowed.
+	///
+	/// Returns an error if `transfer_type` is a reserve transfer and the network's native asset is
+	/// being transferred. Allows the transfer otherwise.
+	fn ensure_one_transfer_type_allowed(
+		assets: &[MultiAsset],
+		transfer_type: &TransferType,
+	) -> Result<(), Error<T>> {
+		// Check if any reserve transfer (LocalReserve, DestinationReserve, or RemoteReserve)
+		// is being attempted.
+		let is_reserve_transfer = matches!(
+			transfer_type,
+			TransferType::LocalReserve |
+				TransferType::DestinationReserve |
+				TransferType::RemoteReserve(_)
+		);
+
+		if !is_reserve_transfer {
+			// If not a reserve transfer (e.g., teleport), allow it.
+			return Ok(());
+		}
+
+		// Check if any asset is a network native asset.
+		for asset in assets {
+			if Self::is_network_native_asset(&asset.id) {
+				tracing::debug!(
+					target: "xcm::pallet_xcm::transfer_assets",
+					asset_id = ?asset.id, ?transfer_type,
+					"Network native asset reserve transfer blocked during Asset Hub Migration. Use `limited_reserve_transfer_assets` instead."
+				);
+				// It's error-prone to try to determine the reserve in this circumstances.
+				return Err(Error::<T>::InvalidAssetUnknownReserve);
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Check if the given asset ID represents a network native asset based on our
+	/// UniversalLocation.
+	///
+	/// Returns true if the asset is a native network asset (DOT, KSM, WND, PAS) that should be
+	/// blocked during Asset Hub Migration.
+	fn is_network_native_asset(asset_id: &AssetId) -> bool {
+		let universal_location = T::UniversalLocation::get();
+		let asset_location = match asset_id {
+            AssetId::Concrete(location) => location,
+            AssetId::Abstract(_) => return false, // What case will this be?
+        };
+
+		match universal_location.len() {
+			// Case 1: We are on the Relay Chain itself.
+			// UniversalLocation: GlobalConsensus(Network).
+			// Network asset ID: Here.
+			1 => {
+				if let Some(Junction::GlobalConsensus(network)) = universal_location.first() {
+					let is_target_network = match network {
+						NetworkId::Polkadot | NetworkId::Kusama => true,
+						NetworkId::ByGenesis(genesis_hash) => {
+							// Check if this is Westend by genesis hash
+							*genesis_hash == WESTEND_GENESIS_HASH ||
+								*genesis_hash == PASEO_GENESIS_HASH ||
+								*genesis_hash == ROCOCO_GENESIS_HASH // Used in tests.
+						},
+						_ => false,
+					};
+					is_target_network && asset_location.is_here()
+				} else {
+					false
+				}
+			},
+			// Case 2: We are on a parachain within one of the specified networks.
+			// UniversalLocation: GlobalConsensus(Network)/Parachain(id).
+			// Network asset ID: Parent.
+			2 => {
+				if let (Some(Junction::GlobalConsensus(network)), Some(Junction::Parachain(_))) =
+					(universal_location.first(), universal_location.last())
+				{
+					let is_target_network = match network {
+						NetworkId::Polkadot | NetworkId::Kusama => true,
+						NetworkId::ByGenesis(genesis_hash) => {
+							// Check if this is Westend by genesis hash
+							*genesis_hash == WESTEND_GENESIS_HASH ||
+								*genesis_hash == PASEO_GENESIS_HASH ||
+								*genesis_hash == ROCOCO_GENESIS_HASH // Used in tests.
+						},
+						_ => false,
+					};
+					is_target_network && *asset_location == MultiLocation::parent()
+				} else {
+					false
+				}
+			},
+			// Case 3: We are not on a relay or parachain. We return false.
+			_ => false,
+		}
+	}
+}

--- a/polkadot/xcm/pallet-xcm/src/transfer_assets_validation.rs
+++ b/polkadot/xcm/pallet-xcm/src/transfer_assets_validation.rs
@@ -24,6 +24,7 @@ use hex_literal::hex;
 use sp_core::Get;
 use xcm::prelude::*;
 use xcm_executor::traits::TransferType;
+use sp_std::vec::Vec;
 
 /// The genesis hash of the Paseo Relay Chain. Used to identify it.
 const PASEO_GENESIS_HASH: [u8; 32] =

--- a/substrate/frame/executive/src/lib.rs
+++ b/substrate/frame/executive/src/lib.rs
@@ -152,6 +152,9 @@ use ::{
 #[allow(dead_code)]
 const LOG_TARGET: &str = "runtime::executive";
 
+/// Maximum nesting level for extrinsics.
+pub const MAX_EXTRINSIC_DEPTH: u32 = 256;
+
 pub type CheckedOf<E, C> = <E as Checkable<C>>::Checked;
 pub type CallOf<E, C> = <CheckedOf<E, C> as Applyable>::Call;
 pub type OriginOf<E, C> = <CallOf<E, C> as Dispatchable>::RuntimeOrigin;
@@ -626,7 +629,14 @@ where
 		let encoded = uxt.encode();
 		let encoded_len = encoded.len();
 		sp_tracing::enter_span!(sp_tracing::info_span!("apply_extrinsic",
-				ext=?sp_core::hexdisplay::HexDisplay::from(&encoded)));
+			ext=?sp_core::hexdisplay::HexDisplay::from(&encoded)));
+
+		let uxt = <Block::Extrinsic as codec::DecodeLimit>::decode_all_with_depth_limit(
+			MAX_EXTRINSIC_DEPTH,
+			&mut &encoded[..],
+		)
+		.expect("Decoding the encoded transaction works; qed");
+
 		// Verify that the signature is good.
 		let xt = uxt.check(&Default::default())?;
 
@@ -703,9 +713,15 @@ where
 
 		enter_span! { sp_tracing::Level::TRACE, "validate_transaction" };
 
-		let encoded_len = within_span! { sp_tracing::Level::TRACE, "using_encoded";
-			uxt.using_encoded(|d| d.len())
+		let encoded = within_span! { sp_tracing::Level::TRACE, "using_encoded";
+			uxt.encode()
 		};
+
+		let uxt = <Block::Extrinsic as codec::DecodeLimit>::decode_all_with_depth_limit(
+			MAX_EXTRINSIC_DEPTH,
+			&mut &encoded[..],
+		)
+		.map_err(|_| InvalidTransaction::Call)?;
 
 		let xt = within_span! { sp_tracing::Level::TRACE, "check";
 			uxt.check(&Default::default())
@@ -721,7 +737,7 @@ where
 
 		within_span! {
 			sp_tracing::Level::TRACE, "validate";
-			xt.validate::<UnsignedValidator>(source, &dispatch_info, encoded_len)
+			xt.validate::<UnsignedValidator>(source, &dispatch_info, encoded.len())
 		}
 	}
 

--- a/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -103,8 +103,7 @@ fn generate_impl_call(
 
 		quote!(
 			#let_binding =
-				match #c::DecodeLimit::decode_all_with_depth_limit(
-					#c::MAX_EXTRINSIC_DEPTH,
+				match #c::Decode::decode(
 					&mut #input,
 				) {
 					Ok(res) => res,


### PR DESCRIPTION
Fix ported from Polkadot-sdk [Pull#9137](https://github.com/paritytech/polkadot-sdk/pull/9137/).

- Tests have not been ported.
- Some types had to be adjusted for version `1.6.0`.


### Test
Runtime was tested with `chopsticks` where an XCM transfer was attempted using `transfer_assets` to send `DOT`. The extrinsic failed with the expected new error:  `InvalidAssetUnknownReserve`.